### PR TITLE
chore: simplify page title to brand name only

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>With Artifact, make lasting artifacts</title>
+    <title>With Artifact</title>
     <meta name="description" content="Make lasting artifacts" />
 
     <!-- Canonical URL -->


### PR DESCRIPTION
- Remove tagline from page title for cleaner presentation